### PR TITLE
Eclipse plugin - added OpenJDK support

### DIFF
--- a/integrations/eclipse/org.eclipse.visualvm.launcher.common/src/org/eclipse/visualvm/launcher/api/VisualVMHelper.java
+++ b/integrations/eclipse/org.eclipse.visualvm.launcher.common/src/org/eclipse/visualvm/launcher/api/VisualVMHelper.java
@@ -114,7 +114,7 @@ public final class VisualVMHelper {
 		try {
 			String line;
 			while ((line = br.readLine()) != null) {
-				if (line.startsWith("java version")) {
+				if (line.startsWith("java version") || line.startsWith("openjdk version")) {
 					int start = line.indexOf("\"");
 					int end = line.lastIndexOf("\"");
 					if (start > -1 && end > -1) {


### PR DESCRIPTION
Eclipse integration plugin fails with NullPointerException when trying to run a project using VisualVM launcher. This fix is necessarry for OpenJDK environments.

I hope that this will be merged, it's a matter of 1 click.