### PR TITLE
Use XDG base directories by default on Unix systems

### DIFF
--- a/visualvm/launcher/visualvm
+++ b/visualvm/launcher/visualvm
@@ -56,8 +56,17 @@ case "`uname`" in
         ;;
     *) 
         # set default userdir and cachedir on unix systems
-        DEFAULT_USERDIR_ROOT=${HOME}/.visualvm
+        if [ -d "${HOME}/.visualvm" ] ; then
+            DEFAULT_USERDIR_ROOT=${HOME}/.visualvm
+        elif [ -n "$XDG_DATA_HOME" ] ; then
+            DEFAULT_USERDIR_ROOT=${XDG_DATA_HOME}/visualvm
+        else
+            DEFAULT_USERDIR_ROOT=${HOME}/.local/share/visualvm
+        fi
         DEFAULT_CACHEDIR_ROOT=${HOME}/.cache/visualvm
+        if [ ! -d "$DEFAULT_CACHEDIR_ROOT" -a -n "$XDG_CACHE_HOME" ] ; then
+            DEFAULT_CACHEDIR_ROOT=${XDG_CACHE_HOME}/visualvm
+        fi
         ;;
 esac
 


### PR DESCRIPTION
See [XDG Base Directory Specification ](https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html).

Chooses userdir as follows:
1. Use `~/.visualvm` if it already exists (so as to not break existing usage),
2. use `$XDG_DATA_HOME/visualvm` if `XDG_DATA_HOME` environment variable is defined and otherwise
3. use `~/.local/share/visualvm`.

Similarly for cachedir:
1. Use `~/.cache/visualvm` if it already exists or if `XDG_CACHE_HOME` environment variable is not defined, but if it is
2. use `$XDG_CACHE_HOME/visualvm`.

