### PR TITLE
GH-89 Include PID if application specifies a custom display name

### DIFF
--- a/visualvm/application/src/org/graalvm/visualvm/application/ApplicationDescriptor.java
+++ b/visualvm/application/src/org/graalvm/visualvm/application/ApplicationDescriptor.java
@@ -145,18 +145,24 @@ public class ApplicationDescriptor extends DataSourceDescriptor<Application> {
             if (propIndex != -1) {  // display name propery detected on commandline
                 propIndex += DISPLAY_NAME_PROPERTY.length();
                 int endIndex = args.indexOf(" ", propIndex); // NOI18N
-                if (endIndex == -1) return args.substring(propIndex);
-                else return args.substring(propIndex, endIndex);
+                String name;
+                if (endIndex == -1) name = args.substring(propIndex);
+                else name = args.substring(propIndex, endIndex);
+                return buildNameWithPid(application, name);
             }
         }
         return null;
     }
     
     private static String createGenericName(Application application, String nameBase) {
+        return buildNameWithPid(application, nameBase);
+    }
+
+    private static String buildNameWithPid(Application application, String name) {
         int pid = application.getPid();
         String id = Application.CURRENT_APPLICATION.getPid() == pid ||
         pid == Application.UNKNOWN_PID ? "" : " (pid " + pid + ")"; // NOI18N
-        return nameBase + id;
+        return name + id;
     }
     
 }


### PR DESCRIPTION
An application can specify `-Dvisualvm.display.name=some-name` to specify a custom name to be displayed in the "Applications" panel in VisualVM. If a display name is specified, VisualVM doesn't include the PID in brackets after the name.

This change causes VisualVM to include the PID when an application specifies a custom name, which makes it easier to distinguish between different instances of the same application.