### PR TITLE
API for creating and processing heap dumps fully in memory

### DIFF
--- a/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/HeapFactory.java
+++ b/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/HeapFactory.java
@@ -32,6 +32,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 
 /**
@@ -86,6 +87,22 @@ public class HeapFactory {
         }
         return new HprofHeap(heapDump, segment, cacheDir);
 
+    }
+
+    /** Factory method for processing heap dumps in memory. When heap data
+     * aren't available on disk, but only in memory, create a {@link ByteBuffer}
+     * from them and use this factory method to create their {@link Heap}
+     * representation.
+     * 
+     * @param buffer data representing the heap dump
+     * @param segment select corresponding dump from multi-dump file
+     * @return implementation of {@link Heap} corresponding to the memory dump
+     * passed in the {@code buffer} parameter
+     * @throws IOException if the access to the buffer fails or data are corrupted
+     * @since 2.2
+     */
+    public static Heap createHeap(ByteBuffer buffer, int segment) throws IOException {
+        return new HprofHeap(buffer, segment, new CacheDirectory(null));
     }
     
     static Heap loadHeap(CacheDirectory cacheDir)

--- a/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/HprofByteBuffer.java
+++ b/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/HprofByteBuffer.java
@@ -27,6 +27,7 @@ package org.graalvm.visualvm.lib.jfluid.heap;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.ResourceBundle;
 
@@ -82,6 +83,10 @@ abstract class HprofByteBuffer {
 
             throw ex;
         }
+    }
+
+    static HprofByteBuffer createHprofByteBuffer(ByteBuffer bb) throws IOException {
+        return new HprofMappedByteBuffer(bb);
     }
 
     abstract char getChar(long index);

--- a/visualvm/libs.profiler/lib.profiler/test/unit/src/org/graalvm/visualvm/lib/jfluid/heap/HeapFromBufferTest.java
+++ b/visualvm/libs.profiler/lib.profiler/test/unit/src/org/graalvm/visualvm/lib/jfluid/heap/HeapFromBufferTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.visualvm.lib.jfluid.heap;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import org.junit.Before;
+
+public class HeapFromBufferTest extends HeapTest {
+    public HeapFromBufferTest() {
+    }
+
+    @Before
+    public void setUp() throws IOException, URISyntaxException {
+        URL url = getClass().getResource("small_heap.bin");
+        File heapFile = new File(url.toURI());
+        ByteBuffer buffer = ByteBuffer.allocate((int) heapFile.length());
+        try (FileChannel ch = new FileInputStream(heapFile).getChannel()) {
+            while (buffer.remaining() > 0) {
+                int len = ch.read(buffer);
+                if (len == -1) {
+                    break;
+                }
+            }
+        }
+        heap = HeapFactory.createHeap(buffer, 0);
+    }
+
+}

--- a/visualvm/libs.profiler/lib.profiler/test/unit/src/org/graalvm/visualvm/lib/jfluid/heap/HeapTest.java
+++ b/visualvm/libs.profiler/lib.profiler/test/unit/src/org/graalvm/visualvm/lib/jfluid/heap/HeapTest.java
@@ -48,9 +48,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.TimeZone;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -59,17 +57,9 @@ import static org.junit.Assert.*;
  * @author Tomas Hurka
  */
 public class HeapTest {
-    private Heap heap;
+    Heap heap;
 
     public HeapTest() {
-    }
-
-    @BeforeClass
-    public static void setUpClass() throws Exception {
-    }
-
-    @AfterClass
-    public static void tearDownClass() throws Exception {
     }
 
     @Before


### PR DESCRIPTION
Wouldn't it be great if Heap dump data could be processed in memory, without the need to create anything on disk? Then it would be possible to analyze heap dumps in restricted environments, where access to disk is restricted. This PR is my attempt to provide such functionality.

Looks like the `HprofMappedByteBuffer` needs the mmapped file only when constructing itself. Then it can operate over regular `ByteBuffer`. Looks like the system is ready to work without the cache directory when `CacheDirectory.cacheDirectory` is `null`.

Adding one new API factory method that takes `ByteBuffer` instead of the `File`. Subclassing `HeapTest` and running the same tests in memory only mode.