### PR TITLE
Eliminate dependency on Swing and call to invokeLater

### DIFF
--- a/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/HprofHeap.java
+++ b/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/HprofHeap.java
@@ -523,7 +523,7 @@ class HprofHeap implements Heap {
             return;
         }
 
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_INSTANCES.start();
         cacheDirectory.setDirty(true);
         ClassDumpSegment classDumpBounds = getClassDumpSegment();
         int idSize = dumpBuffer.getIDSize();
@@ -565,12 +565,12 @@ class HprofHeap implements Heap {
                 instanceEntry.setIndex(classDump.getInstancesCount());
                 classDumpBounds.addInstanceSize(classDump, tag, start);
             }
-            HeapProgress.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
+            handle.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
         }
         instancesCountComputed = true;
         writeToFile();
+        handle.close();
         }
-        HeapProgress.progressFinish();
     }
 
     List findReferencesFor(long instanceId) {
@@ -638,7 +638,7 @@ class HprofHeap implements Heap {
             return;
         }
 
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_INSTANCES.start();
         ClassDumpSegment classDumpBounds = getClassDumpSegment();
         int idSize = dumpBuffer.getIDSize();
         long[] offset = new long[] { allInstanceDumpBounds.startOffset };
@@ -693,7 +693,7 @@ class HprofHeap implements Heap {
                     }
                 }
             }
-            HeapProgress.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
+            handle.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
         }
         
         for (JavaClass cls : getClassDumpSegment().createClassCollection()) {
@@ -715,8 +715,8 @@ class HprofHeap implements Heap {
         idToOffsetMap.flush();
         referencesComputed = true;
         writeToFile();
+        handle.close();
         }
-        HeapProgress.progressFinish();        
     }
     
     void computeRetainedSize() {
@@ -724,7 +724,7 @@ class HprofHeap implements Heap {
         if (retainedSizeComputed) {
             return;
         }
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_RETAINED_SIZE.start();
         LongBuffer leaves = nearestGCRoot.getLeaves();
         cacheDirectory.setDirty(true);
         new TreeObject(this,leaves).computeTrees();
@@ -779,12 +779,12 @@ class HprofHeap implements Heap {
                     entry.setRetainedSize(retainedSize+size);
                 }
             }
-            HeapProgress.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
+            handle.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
         }
         retainedSizeComputed = true;
         writeToFile();
+        handle.close();
         }
-        HeapProgress.progressFinish();
     }
 
     void computeRetainedSizeByClass() {
@@ -794,7 +794,7 @@ class HprofHeap implements Heap {
         }
         computeRetainedSize();
         cacheDirectory.setDirty(true);
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.COMPUTE_RETAINED_SIZE_BY_CLASS.start();
         long[] offset = new long[] { allInstanceDumpBounds.startOffset };
 
         for (long counter=0; offset[0] < allInstanceDumpBounds.endOffset; counter++) {
@@ -810,14 +810,14 @@ class HprofHeap implements Heap {
                     }
                 }
             }
-            HeapProgress.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
+            handle.progress(counter,allInstanceDumpBounds.startOffset,start,allInstanceDumpBounds.endOffset);
         }
         // all done, release domTree
         domTree = null;
         retainedSizeByClassComputed = true;
         writeToFile();
+        handle.close();
         }
-        HeapProgress.progressFinish();
     }
 
     Instance getNearestGCRootPointer(Instance instance) {
@@ -1283,7 +1283,7 @@ class HprofHeap implements Heap {
             return;
         }
 
-        HeapProgress.progressStart();
+        Progress.Handle handle = Progress.FILL_HEAP_TAG_BOUNDS.start();
         heapTagBounds = new TagBounds[0x100];
 
         long[] offset = new long[] { heapDumpSegment.startOffset + 1 + 4 + 4 };
@@ -1311,7 +1311,7 @@ class HprofHeap implements Heap {
             if ((tag == CLASS_DUMP) || (tag == INSTANCE_DUMP) || (tag == OBJECT_ARRAY_DUMP) || (tag == PRIMITIVE_ARRAY_DUMP)) {
                 idMapSize++;
             }
-            HeapProgress.progress(counter,heapDumpSegment.startOffset,start,heapDumpSegment.endOffset);
+            handle.progress(counter,heapDumpSegment.startOffset,start,heapDumpSegment.endOffset);
         }
 
         TagBounds instanceDumpBounds = heapTagBounds[INSTANCE_DUMP];
@@ -1319,7 +1319,7 @@ class HprofHeap implements Heap {
         TagBounds primArrayDumpBounds = heapTagBounds[PRIMITIVE_ARRAY_DUMP];
         allInstanceDumpBounds = instanceDumpBounds.union(objArrayDumpBounds);
         allInstanceDumpBounds = allInstanceDumpBounds.union(primArrayDumpBounds);
-        HeapProgress.progressFinish();
+        handle.close();
     }
 
     private void fillTagBounds(long tagStart) throws IOException {

--- a/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/Progress.java
+++ b/visualvm/libs.profiler/lib.profiler/src/org/graalvm/visualvm/lib/jfluid/heap/Progress.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.graalvm.visualvm.lib.jfluid.heap;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+enum Progress {
+    COMPUTE_INSTANCES,
+    COMPUTE_REFERENCES,
+    FILL_HEAP_TAG_BOUNDS,
+    COMPUTE_GC_ROOTS,
+    COMPUTE_RETAINED_SIZE,
+    COMPUTE_RETAINED_SIZE_BY_CLASS;
+
+    Handle start() {
+        return new Handle(this);
+    }
+
+    private static List<Listener> listeners = Collections.emptyList();
+    synchronized static void register(Listener onChange) {
+        if (listeners.isEmpty()) {
+            listeners = Collections.singletonList(onChange);
+        } else {
+            List<Listener> copy = new ArrayList<>(listeners);
+            copy.add(onChange);
+            listeners = copy;
+        }
+    }
+
+    synchronized static void notifyUpdates(Handle h, int type) {
+        for (Listener onChange : listeners) {
+            switch (type) {
+                case 1: onChange.started(h); break;
+                case 2: onChange.progress(h); break;
+                default: onChange.finished(h);
+            }
+        }
+    }
+
+    static interface Listener {
+        void started(Handle h);
+        void progress(Handle h);
+        void finished(Handle h);
+    }
+
+    static final class Handle implements AutoCloseable {
+        final Progress type;
+        private long value;
+        private long startOffset;
+        private long endOffset;
+
+        private Handle(Progress type) {
+            this.type = type;
+            notifyUpdates(this, 1);
+        }
+
+        void progress(long value, long endValue) {
+            progress(value, 0, value, endValue);
+        }
+
+        void progress(long counter, long startOffset, long value, long endOffset) {
+            // keep this method short so that it can be inlined
+            if (counter % 100000 == 0) {
+                doProgress(value, startOffset, endOffset);
+            }
+        }
+
+        @Override
+        public void close() {
+            notifyUpdates(this, 2);
+        }
+
+        private void doProgress(long value, long startOffset, long endOffset) {
+            this.value = value;
+            this.endOffset = endOffset;
+            this.startOffset = startOffset;
+            notifyUpdates(this, 1);
+        }
+
+        long getValue() {
+            return value;
+        }
+
+        long getStartOffset() {
+            return startOffset;
+        }
+
+        long getEndOffset() {
+            return endOffset;
+        }
+    }
+}


### PR DESCRIPTION
There is a support for reporting progress of long running operations via the  `HeapProgress` class. However this class directly calls into AWT which would better be avoided if the librrary is supposed to be used in a  _headless mode_.

This PR keeps the compatibility with existing `HeapProgress` behavior, yet it avoid the AWT interactions until somebody access `HeapProgress.getProgress()` model.