### PR TITLE
Use dedicated NoMoreSegmentsException to signal end of .hprof file

### DIFF
--- a/visualvm/libs.profiler/lib.profiler.heap/src/org/graalvm/visualvm/lib/jfluid/heap/HprofHeap.java
+++ b/visualvm/libs.profiler/lib.profiler.heap/src/org/graalvm/visualvm/lib/jfluid/heap/HprofHeap.java
@@ -1242,7 +1242,7 @@ class HprofHeap implements Heap {
                 start = offset[0];
             }
 
-            throw new IOException("Invalid segment " + segment); // NOI18N
+            throw new NoMoreSegmentsException(segment);
         } else {
             TagBounds heapDumpSegmentBounds = tagBounds[HEAP_DUMP_SEGMENT];
 
@@ -1272,7 +1272,7 @@ class HprofHeap implements Heap {
 
                     start = offset[0];
                 }
-                throw new IOException("Invalid segment " + segment); // NOI18N
+                throw new NoMoreSegmentsException(segment);
             }
         }
         return null;

--- a/visualvm/libs.profiler/lib.profiler.heap/src/org/graalvm/visualvm/lib/jfluid/heap/NoMoreSegmentsException.java
+++ b/visualvm/libs.profiler/lib.profiler.heap/src/org/graalvm/visualvm/lib/jfluid/heap/NoMoreSegmentsException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.graalvm.visualvm.lib.jfluid.heap;
+
+import java.io.IOException;
+
+final class NoMoreSegmentsException extends IOException {
+    private final int segment;
+
+    NoMoreSegmentsException(int segment) {
+        super("Invalid segment " + segment); // NOI18N
+        this.segment = segment;
+    }
+
+    int getSegment() {
+        return segment;
+    }
+}


### PR DESCRIPTION
<!-- GR-33200 -->


There is a `org.graalvm.visualvm.lib.jfluid.heap.HeapFactory.createHeap(File hprof, int segment)` method to create a `Heap` object for a particular segment in an `.hprof` file. However there doesn't seem to be reliable way to distinguish between corrupted file and non-existing segment.

This PR adds (package private) `NoMoreSegmentsException` that is thrown when the file itself is OK, but the requested segment is missing.