### PR TITLE
Adjusting Polyglot Sampler to GR-54300

### DIFF
--- a/visualvm/sampler.truffle/libsrc/org/graalvm/visualvm/sampler/truffle/stagent/Truffle.java
+++ b/visualvm/sampler.truffle/libsrc/org/graalvm/visualvm/sampler/truffle/stagent/Truffle.java
@@ -32,6 +32,7 @@ import com.oracle.truffle.tools.profiler.HeapSummary;
 import com.oracle.truffle.tools.profiler.StackTraceEntry;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
+import java.lang.ref.Reference;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -41,6 +42,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.graalvm.polyglot.Engine;
@@ -56,7 +58,7 @@ public class Truffle implements TruffleMBean {
 
     private ThreadMXBean threadBean;
     private Method Engine_findActiveEngines;
-    private Map engines;
+    private Set engines;
     private Unsafe unsafe;
     private boolean trackFlags;
 
@@ -165,8 +167,8 @@ public class Truffle implements TruffleMBean {
         return null;
     }
 
-    private Map getEngines() {
-        Map engines = null;
+    private Set getEngines() {
+        Set engines = null;
         try {
             engines = getEnginesFromClass(Engine.class);
             if (engines == null) {
@@ -181,22 +183,29 @@ public class Truffle implements TruffleMBean {
         return engines;
     }
 
-    private Map getEnginesFromClass(Class engineClass) {
+    private Set getEnginesFromClass(Class engineClass) {
         try {
             Field f = engineClass.getDeclaredField("ENGINES");
-            return getEnginesFromField(f);
+            Object v = getEnginesFromField(f);
+            if (v instanceof Set) {
+                return (Set) v;
+            } else {
+                return ((Map) v).keySet();
+            }
         } catch (NoSuchFieldException ex) {
             Logger.getLogger(Truffle.class.getName()).log(TruffleJMX.DEBUG ? Level.INFO : Level.FINE, null, ex);
+        } catch (ClassCastException ex) {
+            Logger.getLogger(Truffle.class.getName()).log(Level.SEVERE, null, ex);
         } catch (SecurityException ex) {
             Logger.getLogger(Truffle.class.getName()).log(Level.SEVERE, null, ex);
         }
         return null;
     }
 
-    private Map getEnginesFromField(Field f) {
+    private Object getEnginesFromField(Field f) {
         try {
             Object base = unsafe.staticFieldBase(f);
-            return (Map) unsafe.getObject(base, unsafe.staticFieldOffset(f));
+            return unsafe.getObject(base, unsafe.staticFieldOffset(f));
         } catch (SecurityException ex) {
             Logger.getLogger(Truffle.class.getName()).log(Level.SEVERE, null, ex);
         }
@@ -207,9 +216,15 @@ public class Truffle implements TruffleMBean {
         try {
             if (Engine_findActiveEngines == null) {
                 Collection<Engine> en = new ArrayList();
-                for (Object o : engines.keySet()) {
+                for (Object o : engines) {
                     Engine e;
 
+                    if (o instanceof Reference) {
+                        o = ((Reference)o).get();
+                    }
+                    if (o == null) {
+                        continue;
+                    }
                     if (o instanceof Engine) {
                         e = (Engine) o;
                     } else {

--- a/visualvm/sampler.truffle/libsrc/org/graalvm/visualvm/sampler/truffle/stagent/TruffleClassLoader.java
+++ b/visualvm/sampler.truffle/libsrc/org/graalvm/visualvm/sampler/truffle/stagent/TruffleClassLoader.java
@@ -98,7 +98,7 @@ class TruffleClassLoader extends ClassLoader {
             ClassLoader loader = (ClassLoader) unsafe.getObject(base, unsafe.staticFieldOffset(f));
             return Collections.singletonList(loader);
         } catch (Exception ex) {
-            Logger.getLogger(TruffleClassLoader.class.getName()).log(Level.SEVERE, null, ex);
+            Logger.getLogger(TruffleClassLoader.class.getName()).log(Level.FINE, null, ex);
         }
         return null;
     }


### PR DESCRIPTION
- There is a problem initializing VisualVM 2.2 _Polyglot Sampler_ with Truffle 25.0.0 when the application is running in _module path_ mode.
- this is caused by [GR-54300 changes](https://github.com/oracle/graal/commit/c6b9e49f953347bf61b4d1ea2ecc3a9ae29c39ca#r178933918) that modified the `ENGINES` field from `Map` to `Set` which remained unnoticed for a while

### Reproduce

- I've created a sample project https://github.com/jtulach/graaljs/tree/GraalJsDemo
- when executed in _module path_ mode: `mvn -Pmodulepath package exec:exec` the VisualVM Polyglot Sampler can't connect
   - everything works in _classpath mode_
   - everything also works when one `--add-opens` access for the access to `findActiveEngines` method...

### Fix

This change modifies the `Unsafe` code of the `stagent` to be ready for `Map` as well as `Set` value being returned from the field.

CCing @tzezula 